### PR TITLE
Workspace promotion conflict resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.0] - 2020-10-05
 - [Command] Add `--conflict` flag to `workspace promote` command.
 
 ## [0.0.2] - 2020-08-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Command] Add `--conflict` flag to `workspace promote` command.
 
 ## [0.0.2] - 2020-08-18
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-workspace
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-workspace/0.0.2 linux-x64 node-v12.18.4
+@vtex/cli-plugin-workspace/0.1.0 linux-x64 node-v12.18.4
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND
@@ -65,7 +65,7 @@ EXAMPLE
   vtex workspace create workspaceName
 ```
 
-_See code: [build/commands/workspace/create.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/create.ts)_
+_See code: [build/commands/workspace/create.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/create.ts)_
 
 ## `oclif-example workspace:delete WORKSPACE1 [ITHWORKSPACE]`
 
@@ -87,7 +87,7 @@ EXAMPLES
   vtex workspace delete workspaceName1 workspaceName2
 ```
 
-_See code: [build/commands/workspace/delete.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/delete.ts)_
+_See code: [build/commands/workspace/delete.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/delete.ts)_
 
 ## `oclif-example workspace:info`
 
@@ -106,7 +106,7 @@ EXAMPLE
   vtex workspace info
 ```
 
-_See code: [build/commands/workspace/info.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/info.ts)_
+_See code: [build/commands/workspace/info.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/info.ts)_
 
 ## `oclif-example workspace:list`
 
@@ -129,7 +129,7 @@ EXAMPLES
   vtex workspace ls
 ```
 
-_See code: [build/commands/workspace/list.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/list.ts)_
+_See code: [build/commands/workspace/list.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/list.ts)_
 
 ## `oclif-example workspace:promote`
 
@@ -164,7 +164,7 @@ EXAMPLES
   vtex promote
 ```
 
-_See code: [build/commands/workspace/promote.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/promote.ts)_
+_See code: [build/commands/workspace/promote.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/promote.ts)_
 
 ## `oclif-example workspace:reset [WORKSPACENAME]`
 
@@ -186,7 +186,7 @@ EXAMPLES
   vtex workspace reset workspaceName
 ```
 
-_See code: [build/commands/workspace/reset.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/reset.ts)_
+_See code: [build/commands/workspace/reset.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/reset.ts)_
 
 ## `oclif-example workspace:status [WORKSPACENAME]`
 
@@ -205,7 +205,7 @@ EXAMPLE
   vtex workspace status
 ```
 
-_See code: [build/commands/workspace/status.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/status.ts)_
+_See code: [build/commands/workspace/status.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/status.ts)_
 
 ## `oclif-example workspace:use WORKSPACE`
 
@@ -230,5 +230,5 @@ EXAMPLES
   vtex use workspaceName
 ```
 
-_See code: [build/commands/workspace/use.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.0.2/build/commands/workspace/use.ts)_
+_See code: [build/commands/workspace/use.ts](https://github.com/vtex/cli-plugin-workspace/blob/v0.1.0/build/commands/workspace/use.ts)_
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-workspace
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-workspace/0.0.2 linux-x64 node-v12.18.3
+@vtex/cli-plugin-workspace/0.0.2 linux-x64 node-v12.18.4
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND
@@ -140,9 +140,21 @@ USAGE
   $ oclif-example workspace:promote
 
 OPTIONS
-  -h, --help     show CLI help
-  -v, --verbose  Show debug level logs
-  --trace        Ensure all requests to VTEX IO are traced
+  -h, --help
+      show CLI help
+
+  -v, --verbose
+      Show debug level logs
+
+  --conflict=master|mine|abort
+      [default: master] Defines how to handle data conflict between workspaces.
+      - master: Keeps data from master unchanged when there are conflicts. Workspace conflicting data is discarded.
+      - mine: Overrides the data on master with the one of the workspace when there is conflict. Any changes on 
+      conflicting data made on master will be lost.
+      - abort: Aborts the workspace promotion when any data conflict is detected.
+
+  --trace
+      Ensure all requests to VTEX IO are traced
 
 ALIASES
   $ oclif-example promote

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ts-jest": "^25.2.1",
     "ts-node": "^8",
     "typescript": "^3.8.2",
-    "vtex": "^2.108.2-beta"
+    "vtex": "2.111.2-beta"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@vtex/cli-plugin-workspace",
   "description": "vtex plugin workspace",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "bugs": "https://github.com/vtex/cli-plugin-workspace/issues",
   "dependencies": {
     "@oclif/command": "^1",

--- a/src/commands/workspace/promote.ts
+++ b/src/commands/workspace/promote.ts
@@ -1,5 +1,27 @@
+import { flags } from '@oclif/command'
+
 import workspacePromote from '../../modules/promote'
 import { CustomCommand } from 'vtex'
+
+const conflictFlagMapping: { [flag: string]: string } = {
+  master: 'Masterwins',
+  mine: 'MineWins',
+  abort: 'Abort',
+}
+
+const conflictFlagDescription = [
+  'Defines how to handle data conflict between workspaces.',
+  '- master: Keeps data from master unchanged when there are conflicts. Workspace conflicting data is discarded.',
+  '- mine: Overrides the data on master with the one of the workspace when there is conflict. Any changes on conflicting data made on master will be lost.',
+  '- abort: Aborts the workspace promotion when any data conflict is detected.',
+].join('\n')
+
+const conflictResolutionFlag = flags.string({
+  description: conflictFlagDescription,
+  options: ['master', 'mine', 'abort'],
+  default: 'master',
+  parse: (flag) => conflictFlagMapping[flag],
+})
 
 export default class WorkspacePromote extends CustomCommand {
   static description = 'Promote this workspace to master'
@@ -10,13 +32,16 @@ export default class WorkspacePromote extends CustomCommand {
 
   static flags = {
     ...CustomCommand.globalFlags,
+    conflict: conflictResolutionFlag,
   }
 
   static args = []
 
   async run() {
-    this.parse(WorkspacePromote)
+    const {
+      flags: { conflict },
+    } = this.parse(WorkspacePromote)
 
-    await workspacePromote()
+    await workspacePromote(conflict)
   }
 }

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -37,18 +37,25 @@ export const Messages = {
     )} to create a production workspace`,
   PROMOTE_SPINNER_START: 'Preparing the workspace to be promoted',
   PROMOTE_CONFLICT_ERROR: (workspace: string, buckets: string[]) =>
-    `${
-      `Couldn't promote workspace ${ColorifyConstants.ID(workspace)}.\n` +
-      `  There are conflicts between ${ColorifyConstants.ID(workspace)} and ${ColorifyConstants.ID(
-        'master'
-      )} in the following data:\n\n`
-    }${buckets.map((bucket) => `    ${bucket}`).join('\n')}\n\n` +
-    `  If you have changed data related to the apps above, any request on workspace ${ColorifyConstants.ID(
-      workspace
-    )} that interacts with the conflicting data may solve the problem.\n` +
-    `  Run ${ColorifyConstants.COMMAND_OR_VTEX_REF(
-      'vtex workspace promote --help'
-    )} to see alternatives conflict resolution strategies for promoting workspaces.`,
+    `\n  ${chalk.bold(
+      `${chalk.red('Error')}: The workspace ${ColorifyConstants.ID(workspace)} couldn't be promoted ` +
+        `because it has conflicts with ${ColorifyConstants.ID('master')}`
+    )}${
+      buckets.length === 0
+        ? chalk.bold('.')
+        : `${`${chalk.bold(' in the following data:')}\n\n` + `${buckets.map((bucket) => `    ${bucket}`).join('\n')}`}`
+    }` +
+    `\n\n  ` +
+    `${chalk.bold(
+      `You can try to resolve the conflicts above with any request on workspace ` +
+        `${ColorifyConstants.ID(workspace)} that interacts with the conficting data.`
+    )}` +
+    `\n  ` +
+    `If you do so you allow the service that handles the data to resolve any conflicts before the workspace promotion.` +
+    `\n\n  ` +
+    `To see alternatives conflict resolution strategies for promoting workspaces, ` +
+    `run ${ColorifyConstants.COMMAND_OR_VTEX_REF('vtex workspace promote --help')}.` +
+    `\n`,
   CONFLICTING_BUCKET_DESCRIPTOR: (bucket: string, app: string) =>
     `• ${ColorifyConstants.ID(bucket)} from app ${ColorifyConstants.ID(app)}`,
 }

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -51,7 +51,7 @@ export const Messages = {
         `${ColorifyConstants.ID(workspace)} that interacts with the conficting data.`
     )}` +
     `\n  ` +
-    `If you do so you allow the service that handles the data to resolve any conflicts before the workspace promotion.` +
+    `By doing so, you allow the service that handles the data to resolve any conflicts before the workspace promotion.` +
     `\n\n  ` +
     `To see alternatives conflict resolution strategies for promoting workspaces, ` +
     `run ${ColorifyConstants.COMMAND_OR_VTEX_REF('vtex workspace promote --help')}.` +

--- a/src/lib/constants/Messages.ts
+++ b/src/lib/constants/Messages.ts
@@ -36,4 +36,19 @@ export const Messages = {
       'vtex workspace create <workspace> --production'
     )} to create a production workspace`,
   PROMOTE_SPINNER_START: 'Preparing the workspace to be promoted',
+  PROMOTE_CONFLICT_ERROR: (workspace: string, buckets: string[]) =>
+    `${
+      `Couldn't promote workspace ${ColorifyConstants.ID(workspace)}.\n` +
+      `  There are conflicts between ${ColorifyConstants.ID(workspace)} and ${ColorifyConstants.ID(
+        'master'
+      )} in the following data:\n\n`
+    }${buckets.map((bucket) => `    ${bucket}`).join('\n')}\n\n` +
+    `  If you have changed data related to the apps above, any request on workspace ${ColorifyConstants.ID(
+      workspace
+    )} that interacts with the conflicting data may solve the problem.\n` +
+    `  Run ${ColorifyConstants.COMMAND_OR_VTEX_REF(
+      'vtex workspace promote --help'
+    )} to see alternatives conflict resolution strategies for promoting workspaces.`,
+  CONFLICTING_BUCKET_DESCRIPTOR: (bucket: string, app: string) =>
+    `• ${ColorifyConstants.ID(bucket)} from app ${ColorifyConstants.ID(app)}`,
 }

--- a/src/modules/promote.ts
+++ b/src/modules/promote.ts
@@ -51,6 +51,19 @@ const isPromotable = async (workspace: string) => {
   spinner.succeed()
 }
 
+const handlePromoteSuccess = async () => {
+  logger.info(Messages.PROMOTE_SUCCESS(currentWorkspace))
+
+  console.log(
+    boxen(Messages.PROMOTE_ASK_FEEDBACK, {
+      padding: 1,
+      margin: 1,
+    })
+  )
+
+  await workspaceUse('master')
+}
+
 const promptPromoteConfirm = (workspace: string): Promise<boolean> =>
   promptConfirm(Messages.PROMOTE_PROMPT_CONFIRM(workspace), true)
 
@@ -67,15 +80,5 @@ export default async () => {
     return
   }
 
-  await promote(account, currentWorkspace)
-  logger.info(Messages.PROMOTE_SUCCESS(currentWorkspace))
-
-  console.log(
-    boxen(Messages.PROMOTE_ASK_FEEDBACK, {
-      padding: 1,
-      margin: 1,
-    })
-  )
-
-  await workspaceUse('master')
+  await promote(account, currentWorkspace).then(handlePromoteSuccess)
 }

--- a/src/modules/promote.ts
+++ b/src/modules/promote.ts
@@ -51,25 +51,24 @@ const isPromotable = async (workspace: string) => {
   spinner.succeed()
 }
 
-const parseInternalBucket = (internalBucket: string): string => {
+const parseInternalBucket = (internalBucket: string): string | null => {
   const [vendor, app, bucket] = internalBucket.split('.')
 
-  return Messages.CONFLICTING_BUCKET_DESCRIPTOR(bucket, `${vendor}.${app}`)
+  return bucket != null ? Messages.CONFLICTING_BUCKET_DESCRIPTOR(bucket, `${vendor}.${app}`) : null
 }
 
 const parseConflictMessage = (message: string): string[] => {
   const [, buckets] = message.split(':')
   const internalBuckets = buckets.split(',').map((bucket) => bucket.trim())
 
-  return internalBuckets.map(parseInternalBucket)
+  return internalBuckets.map(parseInternalBucket).filter((bucket) => bucket != null) as string[]
 }
 
 const handleConflictOnPromote = (workspace: string, e: AxiosError) => {
   if (e.response?.status !== 409) throw e
-
   const buckets = parseConflictMessage(e.response.data.message)
 
-  throw createFlowIssueError(Messages.PROMOTE_CONFLICT_ERROR(workspace, buckets))
+  console.log(Messages.PROMOTE_CONFLICT_ERROR(workspace, buckets))
 }
 
 const handlePromoteSuccess = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,6 +799,11 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
+"@types/diff@^4.0.2":
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/diff/-/diff-4.0.2.tgz#2e9bb89f9acc3ab0108f0f3dc4dbdcf2fff8a99c"
+  integrity sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ==
+
 "@types/eslint-visitor-keys@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
@@ -1084,10 +1089,10 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@vtex/api@3.71.1":
-  version "3.71.1"
-  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.71.1.tgz#996a9148cceadb8cd68939f47ce739b88b6bad97"
-  integrity sha512-CurrRU1U/svHbbyvhsICD8/IqtSQplH/AzS9q0iQ0OC6AH4H8hLUvaNuFMIDW4jSMInqepqKkcS3BQsw9wBxBQ==
+"@vtex/api@^3.76.0":
+  version "3.76.0"
+  resolved "https://registry.yarnpkg.com/@vtex/api/-/api-3.76.0.tgz#3ef58dc030517e75885bf11448ed21a6ba54ed3f"
+  integrity sha512-X3NGq6ErcTqJWhJN4WPfkmaw7oT1w5RqQ0NlyARwS3KXUqR4FKvWeXl+uC/1mxllrmVcDZwtb1n+2HuxpZgDBg==
   dependencies:
     "@types/koa" "^2.0.48"
     "@types/koa-compose" "^3.2.3"
@@ -1133,6 +1138,18 @@
     numbro "2.1.0"
     tslib "^1"
 
+"@vtex/cli-plugin-deps@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-deps/-/cli-plugin-deps-0.0.1.tgz#6e07e1951f1a02719d800b08d92b73cb94d7c417"
+  integrity sha512-T0Zm7ByLjYm78K0jquCvZc7jbhiXtorFAGphW22iiPKxs8WtUX/VNqTsx0wHJOG2H5lnL3NE7PjiG4Aavi7K+g==
+  dependencies:
+    "@oclif/command" "^1"
+    "@oclif/config" "^1"
+    "@tiagonapoli/oclif-plugin-spaced-commands" "^0.0.6"
+    "@types/diff" "^4.0.2"
+    "@types/ramda" "^0.27.14"
+    tslib "^1"
+
 "@vtex/cli-plugin-edition@^0.0.1":
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-edition/-/cli-plugin-edition-0.0.1.tgz#b0c7f922b9b183fa470ee251f75ae57b94596115"
@@ -1153,10 +1170,10 @@
     "@tiagonapoli/oclif-plugin-spaced-commands" "^0.0.6"
     tslib "^1"
 
-"@vtex/cli-plugin-redirects@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-redirects/-/cli-plugin-redirects-0.0.1.tgz#8ff1998843861e8d9d0c9bb2734d2c167ab5b6d9"
-  integrity sha512-B4oCNhfW10R/5FYtpCvMPRw5B9dmAaKYqR5PbYrLVxCNtzqLOAFWrFHd4xzuvLaoZnWQJh0p/cyBswbE/3WHCQ==
+"@vtex/cli-plugin-redirects@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-redirects/-/cli-plugin-redirects-0.0.2.tgz#de993cd0d6ae1b5106fc524225debecb87dac7b9"
+  integrity sha512-CCUYv2U6fgQ16ZZV7DOeVE8p/I16TQ8LU1qrRF78Jk9BdYseDnPKlSRK9alGUmXqB6rSrgacun/De/vn8xAhgA==
   dependencies:
     "@oclif/command" "^1"
     "@oclif/config" "^1"
@@ -1167,7 +1184,18 @@
     "@types/ramda" "^0.27.14"
     json-array-split "^1.0.0"
     json2csv "^5.0.1"
+    progress "^2.0.3"
     tslib "^1"
+
+"@vtex/cli-plugin-submit@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-submit/-/cli-plugin-submit-0.1.0.tgz#23fb0668f4a1c582b655bd35988dc6d9f751693c"
+  integrity sha512-Rcza9+mN0mRAy31f9TnfW8U2cSaFQfeZmXy5P6IzugvIIB2C/uFPb+qtzAPbSvou26H84pEZHNVJ/C/Woasyng==
+  dependencies:
+    "@oclif/command" "^1"
+    "@oclif/config" "^1"
+    inquirer "^7.3.3"
+    tslib "^2.0.1"
 
 "@vtex/cli-plugin-test@^0.0.5":
   version "0.0.5"
@@ -1181,10 +1209,10 @@
     chalk "^4.1.0"
     tslib "^1"
 
-"@vtex/cli-plugin-workspace@^0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-workspace/-/cli-plugin-workspace-0.0.1.tgz#02a33a43f00ebd2bf826f6793bc472bad3dbbf2e"
-  integrity sha512-UPEVUeq9ZzxEN4csd7LFwfiOSYtQIzw8jCfeI17CU7mi81+KOU67vWDYcyUMDbz/4jNWPIobhUjf1/ROHcBCYQ==
+"@vtex/cli-plugin-workspace@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@vtex/cli-plugin-workspace/-/cli-plugin-workspace-0.0.2.tgz#c02efb9f211406b5c1b30b9b81156357f3a4e94d"
+  integrity sha512-bhRqC/SYXvw6Dy7IhL8S/EaCl/JxcPCG6J707RC6DC4m702DODfwdeXwtqZ671q1GAB+z850TlK90hNJuLpqDA==
   dependencies:
     "@oclif/command" "^1"
     "@oclif/config" "^1"
@@ -4693,6 +4721,25 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 into-stream@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-3.1.0.tgz#96fb0a936c12babd6ff1752a17d05616abd094c6"
@@ -6024,6 +6071,11 @@ lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 log-ok@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/log-ok/-/log-ok-0.1.1.tgz#bea3dd36acd0b8a7240d78736b5b97c65444a334"
@@ -7011,7 +7063,7 @@ process-nextick-args@~2.0.0:
   resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
   integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
-progress@^2.0.0:
+progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
@@ -7985,7 +8037,7 @@ static-extend@^0.1.1, static-extend@^0.1.2:
     define-property "^0.2.5"
     object-copy "^0.1.0"
 
-stats-lite@vtex/node-stats-lite#dist:
+"stats-lite@github:vtex/node-stats-lite#dist":
   version "2.2.0"
   resolved "https://codeload.github.com/vtex/node-stats-lite/tar.gz/1b0d39cc41ef7aaecfd541191f877887a2044797"
   dependencies:
@@ -8524,6 +8576,11 @@ tslib@^1, tslib@^1.0.0, tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
 
+tslib@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
+  integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
+
 tsscmp@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
@@ -8809,22 +8866,24 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vtex@^2.108.2-beta:
-  version "2.108.2-beta"
-  resolved "https://registry.yarnpkg.com/vtex/-/vtex-2.108.2-beta.tgz#16feb6144e91ad471a79bcbe846f9e8dc3cd08f4"
-  integrity sha512-k6T7YHN1549MMx72nt94UnW8tArFP2D1HYNGZ7QunYPQZTGyojErIwmgHstyRDyHM+dyvPq8nsAuYAAFNIszRg==
+vtex@2.111.2-beta:
+  version "2.111.2-beta"
+  resolved "https://registry.yarnpkg.com/vtex/-/vtex-2.111.2-beta.tgz#da18bbb4d9be1aa9d8e2b4a0253e3c360697e8f7"
+  integrity sha512-FEPayC0vqMWSaOjRwZ3vyyNP/JpST95aD5I4RMze6mqOzOfCp4O4Z+lFrLZe/LPPxoNyoa8hDUHsZXmkC7KIpw==
   dependencies:
     "@oclif/command" "^1.0.0"
     "@oclif/config" "^1.0.0"
     "@oclif/plugin-help" "^2.0.0"
     "@tiagonapoli/oclif-plugin-spaced-commands" "^0.0.6"
-    "@vtex/api" "3.71.1"
+    "@vtex/api" "^3.76.0"
     "@vtex/cli-plugin-abtest" "^0.0.5"
+    "@vtex/cli-plugin-deps" "^0.0.1"
     "@vtex/cli-plugin-edition" "^0.0.1"
     "@vtex/cli-plugin-lighthouse" "^0.0.3"
-    "@vtex/cli-plugin-redirects" "^0.0.1"
+    "@vtex/cli-plugin-redirects" "^0.0.2"
+    "@vtex/cli-plugin-submit" "^0.1.0"
     "@vtex/cli-plugin-test" "^0.0.5"
-    "@vtex/cli-plugin-workspace" "^0.0.1"
+    "@vtex/cli-plugin-workspace" "^0.0.2"
     "@vtex/node-error-report" "^0.0.2"
     "@vtex/toolbelt-message-renderer" "^0.0.1"
     "@yarnpkg/lockfile" "^1.1.0"


### PR DESCRIPTION
#### What is the purpose of this pull request?
To add a `--conflict` flag on `workspace promote` command.
The flag must have one of three values:
- `master`: preserves value from master when data has conflict. [default]
- `mine`: overrides data from master with value from workspace when there is any conflict.
- `abort`: aborts workspace promotion if any conflict exist.

#### What problem is this solving?
Default conflict handling strategy not being enough for end users - e.g. Motorola.

#### How should this be manually tested?
Just cause a conflict in a workspace and then try to promote it with the different flags.

#### Screenshots or example usage
<img width="942" alt="Screen Shot 2020-09-15 at 23 22 36" src="https://user-images.githubusercontent.com/7853668/93285032-58878980-f7aa-11ea-91a0-58773f5db8f7.png">

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`