### PR TITLE
Fix names of options for conflictResolutionStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- [Fix] Fix the values that can be passed to the `conflictResolutionFlag`.
 
 ## [0.1.0] - 2020-10-05
 - [Command] Add `--conflict` flag to `workspace promote` command.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install -g @vtex/cli-plugin-workspace
 $ oclif-example COMMAND
 running command...
 $ oclif-example (-v|--version|version)
-@vtex/cli-plugin-workspace/0.1.0 linux-x64 node-v12.18.4
+@vtex/cli-plugin-workspace/0.1.0 linux-x64 node-v12.19.0
 $ oclif-example --help [COMMAND]
 USAGE
   $ oclif-example COMMAND
@@ -146,8 +146,8 @@ OPTIONS
   -v, --verbose
       Show debug level logs
 
-  --conflict=master|mine|abort
-      [default: master] Defines how to handle data conflict between workspaces.
+  --conflict=masterWins|mineWins|abort
+      [default: masterWins] Defines how to handle data conflict between workspaces.
       - master: Keeps data from master unchanged when there are conflicts. Workspace conflicting data is discarded.
       - mine: Overrides the data on master with the one of the workspace when there is conflict. Any changes on 
       conflicting data made on master will be lost.

--- a/src/commands/workspace/promote.ts
+++ b/src/commands/workspace/promote.ts
@@ -18,8 +18,8 @@ const conflictFlagDescription = [
 
 const conflictResolutionFlag = flags.string({
   description: conflictFlagDescription,
-  options: ['master', 'mine', 'abort'],
-  default: 'master',
+  options: ['masterWins', 'mineWins', 'abort'],
+  default: 'masterWins',
   parse: (flag) => conflictFlagMapping[flag],
 })
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
To fix the name of the options for the `conflictResolutionFlag`.

#### What problem is this solving?
It is impossible to promote with the wrong value.

#### How should this be manually tested?
Link toolbelt and promote a workspace.

#### Screenshots or example usage
`vtex promote`

#### Types of changes
- [ ] Refactor (non-breaking change that only makes the code better)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Chores checklist
- [x] Update `CHANGELOG.md`
